### PR TITLE
Update README.md: add links, and fix list of depencies of js_of_ocaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,48 @@
 [MariOCaml](https://mahsu.github.io/mariocaml/)
 =============
-MariOCaml is an HTML 5 canvas web-browser implementation of the Super Mario Bros platformer written exclusively in Ocaml.
+MariOCaml is an HTML 5 canvas web-browser implementation of the [Super Mario Bros](https://en.wikipedia.org/wiki/Super_Mario_Bros.) platformer written exclusively in [Ocaml](https://www.ocaml.org/).
 
 ![Gameplay preview](https://github.com/mahsu/MariOCaml/raw/master/screenshots/preview.gif)
 
-[Try it out!](https://mahsu.github.io/mariocaml/)
+[Try it out online!](https://mahsu.github.io/mariocaml/)
 
 ## Key Features
 * 2D Mario platformer that emulates the platformer mechanics of Super Mario Bros.
-* Web-based playable implementation with graphics (Ocaml transpiled to javascript).
+* Web-based playable implementation with graphics (Ocaml transpiled to Javascript).
 * Procedural level generator that randomly generates levels.
 
 ## Description
 MariOcaml is an OCaml implementation of Super Mario Bros. The game includes several basic enemies, blocks, and items, with particle support. The underlying system follows a director model, with the director maintaining state based on game objects and tiles, including Mario, items, and obstacles. The implementation of enemies and items is designed to be easily extensible. Furthermore, MariOcaml supports a game-over and game-win states, as well as score and coin counts, emulating several of the core mechanics of Mario.
 
-The design follows a clean, modular, and extensible system to ensure that more features can easily be added. Levels are procedurally generated (pseudo-randomly), algorithmically creating an environment of textures and objects that are interactable. The procedural generation generally generates a playable map, but due to the nature of random generation, maps may not be the most aesthetically appealing. Additionally, the game is interactive and graphical using js\_of\_ocaml, which enables cross-compiliation of Ocaml to javascript, allowing MariOcaml to be run in any modern web browser.
+The design follows a clean, modular, and extensible system to ensure that more features can easily be added. Levels are procedurally generated (pseudo-randomly), algorithmically creating an environment of textures and objects that are interactable. The procedural generation generally generates a playable map, but due to the nature of random generation, maps may not be the most aesthetically appealing. Additionally, the game is interactive and graphical using `js_of_ocaml`, which enables cross-compiliation of Ocaml to javascript, allowing MariOcaml to be run in any modern web browser.
 
 The underlying procedural generation utilizes a grid system to generate objects, taking account parameters such as proximity and location. During game-play, the director maintains the game state, including the location and status of both items, enemies, and the character.
 
 ## Modules
-* **Director** - The heart of the game, executes the main game loop and performs updates on the map, canvas, and objects. Also executes the side effectual collision detection.
-* **Viewport** - Represents a slice of the game map which is currently in view and rendered on the canvas.
-* **Procedural Generator** - Generates the game level in a game map to be played.
-* **Actors** - Represents the characters, items, and obstacles in the Mario game world.
-* **Sprite** - The visual representation of an object to be drawn on the canvas. Contains the ability to create sprites from a template configuration based on the type of actor.
-* **Object** - The abstract representation of a specific actor on the game map. Contains the ability to create objects from a template configuration based on the type of actor.
-* **Particle** - Represents a non-collidable visually oriented object on the map. This includes destruction and creation effects.
-* **Draw** - Contains methods which update the canvas.
+* **Director** - The heart of the game, executes the main game loop and performs updates on the map, canvas, and objects. Also executes the side effectual collision detection (files [director.ml](director.ml) and [director.mli](director.mli)).
+* **Viewport** - Represents a slice of the game map which is currently in view and rendered on the canvas (files [viewport.ml](viewport.ml) and [viewport.mli](viewport.mli)).
+* **Procedural Generator** - Generates the game level in a game map to be played (files [procedural.ml](procedural.ml) and [procedural.mli](procedural.mli)).
+* **Actors** - Represents the characters, items, and obstacles in the Mario game world (files [actors.ml](actors.ml) and [actors.mli](actors.mli)).
+* **Sprite** - The visual representation of an object to be drawn on the canvas. Contains the ability to create sprites from a template configuration based on the type of actor (files [sprite.ml](sprite.ml) and [sprite.mli](sprite.mli)).
+* **Object** - The abstract representation of a specific actor on the game map. Contains the ability to create objects from a template configuration based on the type of actor (files [object.ml](object.ml) and [object.mli](object.mli)).
+* **Particle** - Represents a non-collidable visually oriented object on the map. This includes destruction and creation effects (files [particle.ml](particle.ml) and [particle.mli](particle.mli)).
+* **Draw** - Contains methods which update the canvas (files [draw.ml](draw.ml) and [draw.mli](draw.mli)).
 
 ## Building the Project
-1. First, ensure that js\_of\_ocaml (>= 2.6) and its dependencies are installed by running:
 
-        opam install js_of_ocaml
-2. With ocamlbuild installed, run:
+1. First, ensure that [`ocamlbuild`](https://github.com/ocaml/ocamlbuild) and [`js_of_ocaml`](https://github.com/ocsigen/js_of_ocaml) (>= 2.6) and its dependencies are installed by running:
+
+        opam install ocamlbuild js_of_ocaml js_of_ocaml-ocamlbuild js_of_ocaml-camlp4
+
+2. (If you don't have `opam` installed, [see the official instructions](https://opam.ocaml.org/doc/Install.html))
+
+3. With `ocamlbuild` installed, run:
 
         make all
-to compile the binaries to the `_build` folder and run the jsoo cross-compiler.
 
-3. Open `index.html` to run!
+to compile the binaries to the `_build` folder and run the `js_of_ocaml` cross-compiler.
+
+4. Open `index.html` in a web-browser to run the game!
 
 ## Contributing
 Pull requests fixing bugs, adding functionality, or improving organization are welcome!


### PR DESCRIPTION
Hello there,
Big fan of Mario and CS teacher using and teaching OCaml, so I love your MariOCaml game as it's a really sweet example of what OCaml + `js_of_ocaml` can be used for.

I noticed that installing just
```bash
$ opam install js_of_ocaml
```
failed, and `js_of_ocaml` actually requires two more packages to be used with `ocamlbuild`, `js_of_ocaml-ocamlbuild` and `js_of_ocaml-camlp4`, I added them on this PR.

I also added a few links to OCaml, `js_of_ocaml` and `ocamlbuild` websites.

Regards from France, -- @Naereen